### PR TITLE
Add flag for alumnus on member model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,3 +483,6 @@ DEPENDENCIES
   title (~> 0.0.5)
   turbolinks (~> 2.5.1)
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.2

--- a/app/controllers/admins/members_controller.rb
+++ b/app/controllers/admins/members_controller.rb
@@ -42,7 +42,7 @@ module Admins
     private
 
     def member_params
-      params.require(:member).permit(:last_name, :first_name, :email, :member_role_id)
+      params.require(:member).permit(:last_name, :first_name, :email, :member_role_id, :is_alumnus)
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,8 @@ class PagesController < ApplicationController
   end
 
   def about
-    @members = Member.all.sort_by(&:member_role)
+    @members = Member.current.sort_by(&:member_role)
+    @alumni = Member.alumni.sort_by(&:member_role)
   end
 
   def sponsors

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -14,6 +14,9 @@
 class Member < ActiveRecord::Base
   belongs_to :member_role
 
+  scope :current, -> { where(is_alumnus: false) }
+  scope :alumni, -> { where(is_alumnus: true) }
+
   validates :last_name, presence: true
   validates :first_name, presence: true
   validates :email, presence: true

--- a/app/views/admins/members/_form.html.slim
+++ b/app/views/admins/members/_form.html.slim
@@ -8,4 +8,6 @@
   br
   = f.association :member_role, label: 'Role:'
   br
+  = f.input :is_alumnus, label: 'Alumnus?'
+  br
   = f.submit submit_text

--- a/app/views/pages/about.html.slim
+++ b/app/views/pages/about.html.slim
@@ -82,3 +82,20 @@
                     .name
                       b = member
                     .position = member.member_role
+  .spacer-small
+  .row
+    .small-9.small-centered.columns
+      h3.team-title Alumni
+  .row
+    .small-12.small-centered.columns
+      ul.team-pictures.medium-block-grid-4.small-block-grid-2
+        - @alumni.each do |alumnus|
+          li.team-picture-item
+            figure.effect-sadie
+              a href="javascript:void(0)"
+                = image_tag gravatar_url(alumnus.email)
+                figcaption
+                  .member-description
+                    .name
+                      b = alumnus
+                    .position = alumnus.member_role

--- a/db/migrate/20150826194109_add_alumnus_to_member.rb
+++ b/db/migrate/20150826194109_add_alumnus_to_member.rb
@@ -1,0 +1,5 @@
+class AddAlumnusToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :is_alumnus, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150825192509) do
+ActiveRecord::Schema.define(version: 20150826194109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20150825192509) do
     t.string   "first_name"
     t.string   "email"
     t.integer  "member_role_id"
+    t.boolean  "is_alumnus",     default: false
   end
 
   add_index "members", ["member_role_id"], name: "index_members_on_member_role_id", using: :btree


### PR DESCRIPTION
This PR allows alumni to be marked as alumni while retaining their former titles. They will now be placed after the current members on the about page. 

![aboutpage](https://cloud.githubusercontent.com/assets/5482714/9506634/256134dc-4bfe-11e5-85fb-98f142367e33.png)
