### PR TITLE
Fix circles on mobile on about page

### DIFF
--- a/app/assets/stylesheets/pages/about.scss
+++ b/app/assets/stylesheets/pages/about.scss
@@ -135,25 +135,15 @@
 .hover-icon {
   position: relative;
 
-  @include media(max-width $large-screen) {
-    img {
-      left: 0;
-      position: relative;
-    }
-
-    .icon-bottom {
-      display: none;
-    }
-
-    img.icon-top:hover {
-      opacity: 1;
-    }
-  }
-
   img {
     @include transition(opacity 0.3s ease-in-out);
     left: 0;
-    position: absolute;
+    position: relative;
+
+    &.icon-top {
+      position: absolute;
+      top: 0;
+    }
 
     &.icon-top:hover {
       opacity: 0;

--- a/app/assets/stylesheets/shared/general.scss
+++ b/app/assets/stylesheets/shared/general.scss
@@ -71,6 +71,13 @@
   }
 }
 
+// Show on different screen sizes
+.show-on-large-up {
+  @media only screen and (max-width: $large-screen) {
+    display: none;
+  }
+}
+
 // Use to make your text white when putting over dark, color, or photo backgrounds.
 .white {
   color: $white;

--- a/app/views/pages/about.html.slim
+++ b/app/views/pages/about.html.slim
@@ -13,51 +13,42 @@
       .spacer-small
 .about-detail-block
   a#linkto-traits.prev
+  .spacer
   .row
     .medium-4.columns
-      .spacer
       .about-value
         .icon-wrapper
           .hover-icon
             = image_tag("about/craft-hover.png", class: "icon-bottom")
             = image_tag("about/craft.png", class: "icon-top")
-        .spacer-small
     .medium-8.columns
-      .spacer
       .about-value
-        .spacer
+        .spacer.show-on-large-up
         p = t ".values.craft"
-        .spacer-small
+  .spacer-small
   .row
-    .medium-8.columns
-      .spacer
-      .about-value
-        .spacer
-        p = t ".values.culture"
-        .spacer
-    .medium-4.columns
-      .spacer
+    .medium-4.columns.medium-push-8
       .about-value
         .icon-wrapper
           .hover-icon
             = image_tag("about/culture-hover.png", class: "icon-bottom")
             = image_tag("about/culture.png", class: "icon-top")
-        .spacer-small
+    .medium-8.columns.medium-pull-4
+      .about-value
+        .spacer.show-on-large-up
+        p = t ".values.culture"
+  .spacer-small
   .row
     .medium-4.columns
-      .spacer
       .about-value
         .icon-wrapper
           .hover-icon
             = image_tag("about/heart-hover.png", class: "icon-bottom")
             = image_tag("about/heart.png", class: "icon-top")
-        .spacer-small
     .medium-8.columns
-      .spacer
       .about-value
-        .spacer
+        .spacer.show-on-large-up
         p = t ".values.heart"
-        .spacer-small
   .spacer
   .spacer
 .spacer


### PR DESCRIPTION
This makes the circles work on mobile on the about page. 

![mobileabout](https://cloud.githubusercontent.com/assets/5482714/9552958/c4e05628-4d70-11e5-8a30-6ea54d067400.png)
