### PR TITLE
Fix mailchimp signup binding

### DIFF
--- a/app/assets/javascripts/shared/mailchimp.js
+++ b/app/assets/javascripts/shared/mailchimp.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+function mailchimp() {
   $(".newsletter-form").each(function(id, form) {
     $(form).children("button").one("click", function(){
       if ($(form).children("input").val()) {
@@ -23,4 +23,6 @@ $(document).ready(function() {
       }
     });
   });
-});
+}
+
+ready(mailchimp);


### PR DESCRIPTION
This uses our ready utility to bind mailchimp on turbolink loads because document.ready never gets fired. 

@SamLau95 or @aykamko can you take a look and deploy asap?