### PR TITLE
Updated Migration File Version Numbers (required for rails 5)

### DIFF
--- a/db/migrate/20141108222528_create_users.rb
+++ b/db/migrate/20141108222528_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.timestamps

--- a/db/migrate/20141108222816_add_devise_to_users.rb
+++ b/db/migrate/20141108222816_add_devise_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseToUsers < ActiveRecord::Migration
+class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20141109225632_add_role_to_user.rb
+++ b/db/migrate/20141109225632_add_role_to_user.rb
@@ -1,4 +1,4 @@
-class AddRoleToUser < ActiveRecord::Migration
+class AddRoleToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :role, :integer, default: 0
   end

--- a/db/migrate/20141110034855_remove_trackable_from_users.rb
+++ b/db/migrate/20141110034855_remove_trackable_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveTrackableFromUsers < ActiveRecord::Migration
+class RemoveTrackableFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :sign_in_count, :integer, default: 0, null: false
     remove_column :users, :current_sign_in_at, :datetime

--- a/db/migrate/20141110091616_devise_invitable_add_to_users.rb
+++ b/db/migrate/20141110091616_devise_invitable_add_to_users.rb
@@ -1,4 +1,4 @@
-class DeviseInvitableAddToUsers < ActiveRecord::Migration
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[4.2]
   def up
     change_table :users do |t|
       t.string     :invitation_token

--- a/db/migrate/20141129080303_create_contact_forms.rb
+++ b/db/migrate/20141129080303_create_contact_forms.rb
@@ -1,4 +1,4 @@
-class CreateContactForms < ActiveRecord::Migration
+class CreateContactForms < ActiveRecord::Migration[4.2]
   def change
     create_table :contact_forms do |t|
       t.timestamps

--- a/db/migrate/20150221234751_rename_user_to_admin.rb
+++ b/db/migrate/20150221234751_rename_user_to_admin.rb
@@ -1,4 +1,4 @@
-class RenameUserToAdmin < ActiveRecord::Migration
+class RenameUserToAdmin < ActiveRecord::Migration[4.2]
   def change
     rename_table :users, :admins
   end

--- a/db/migrate/20150221235631_create_projects.rb
+++ b/db/migrate/20150221235631_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :projects do |t|
       t.string :title

--- a/db/migrate/20150222022116_create_applicants.rb
+++ b/db/migrate/20150222022116_create_applicants.rb
@@ -1,4 +1,4 @@
-class CreateApplicants < ActiveRecord::Migration
+class CreateApplicants < ActiveRecord::Migration[4.2]
   def change
     create_table :applicants do |t|
       t.timestamps

--- a/db/migrate/20150222033520_add_devise_to_applicants.rb
+++ b/db/migrate/20150222033520_add_devise_to_applicants.rb
@@ -1,4 +1,4 @@
-class AddDeviseToApplicants < ActiveRecord::Migration
+class AddDeviseToApplicants < ActiveRecord::Migration[4.2]
   def change
     change_table(:applicants) do |t|
       ## Database authenticatable

--- a/db/migrate/20150222035150_create_identities.rb
+++ b/db/migrate/20150222035150_create_identities.rb
@@ -1,4 +1,4 @@
-class CreateIdentities < ActiveRecord::Migration
+class CreateIdentities < ActiveRecord::Migration[4.2]
   def change
     create_table :identities do |t|
       t.references :applicant, index: true

--- a/db/migrate/20150301000844_create_apps.rb
+++ b/db/migrate/20150301000844_create_apps.rb
@@ -1,4 +1,4 @@
-class CreateApps < ActiveRecord::Migration
+class CreateApps < ActiveRecord::Migration[4.2]
   def change
     create_table :apps do |t|
       t.timestamps

--- a/db/migrate/20150302052646_add_applicant_id_to_apps.rb
+++ b/db/migrate/20150302052646_add_applicant_id_to_apps.rb
@@ -1,4 +1,4 @@
-class AddApplicantIdToApps < ActiveRecord::Migration
+class AddApplicantIdToApps < ActiveRecord::Migration[4.2]
   def change
     add_column :apps, :applicant_id, :integer
     add_index :apps, :applicant_id

--- a/db/migrate/20150302054404_remove_all_apps_fields.rb
+++ b/db/migrate/20150302054404_remove_all_apps_fields.rb
@@ -1,4 +1,4 @@
-class RemoveAllAppsFields < ActiveRecord::Migration
+class RemoveAllAppsFields < ActiveRecord::Migration[4.2]
   def change
     remove_column :apps, :last_name, :string
     remove_column :apps, :first_name, :string

--- a/db/migrate/20150308033616_create_members.rb
+++ b/db/migrate/20150308033616_create_members.rb
@@ -1,4 +1,4 @@
-class CreateMembers < ActiveRecord::Migration
+class CreateMembers < ActiveRecord::Migration[4.2]
   def change
     create_table :members do |t|
       t.timestamps

--- a/db/migrate/20150315214321_create_semesters.rb
+++ b/db/migrate/20150315214321_create_semesters.rb
@@ -1,4 +1,4 @@
-class CreateSemesters < ActiveRecord::Migration
+class CreateSemesters < ActiveRecord::Migration[4.2]
   def change
     create_table :semesters do |t|
       t.timestamps

--- a/db/migrate/20150316212014_add_semester_id_to_apps.rb
+++ b/db/migrate/20150316212014_add_semester_id_to_apps.rb
@@ -1,4 +1,4 @@
-class AddSemesterIdToApps < ActiveRecord::Migration
+class AddSemesterIdToApps < ActiveRecord::Migration[4.2]
   def change
     add_column :apps, :semester_id, :integer
     add_index :apps, :semester_id

--- a/db/migrate/20150316212023_add_semester_id_to_projects.rb
+++ b/db/migrate/20150316212023_add_semester_id_to_projects.rb
@@ -1,4 +1,4 @@
-class AddSemesterIdToProjects < ActiveRecord::Migration
+class AddSemesterIdToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :semester_id, :integer
     add_index :projects, :semester_id

--- a/db/migrate/20150316234146_remove_year_from_apps.rb
+++ b/db/migrate/20150316234146_remove_year_from_apps.rb
@@ -1,4 +1,4 @@
-class RemoveYearFromApps < ActiveRecord::Migration
+class RemoveYearFromApps < ActiveRecord::Migration[4.2]
   def change
     remove_column :apps, :year, :string
   end

--- a/db/migrate/20150317010432_add_current_semester_column.rb
+++ b/db/migrate/20150317010432_add_current_semester_column.rb
@@ -1,4 +1,4 @@
-class AddCurrentSemesterColumn < ActiveRecord::Migration
+class AddCurrentSemesterColumn < ActiveRecord::Migration[4.2]
   def change
     add_column :semesters, :is_current_semester, :boolean, default: false
   end

--- a/db/migrate/20150407023813_rename_apps_to_student_applications.rb
+++ b/db/migrate/20150407023813_rename_apps_to_student_applications.rb
@@ -1,4 +1,4 @@
-class RenameAppsToStudentApplications < ActiveRecord::Migration
+class RenameAppsToStudentApplications < ActiveRecord::Migration[4.2]
   def change
     rename_table :apps, :student_applications
   end

--- a/db/migrate/20150407025722_create_final_decisions.rb
+++ b/db/migrate/20150407025722_create_final_decisions.rb
@@ -1,4 +1,4 @@
-class CreateFinalDecisions < ActiveRecord::Migration
+class CreateFinalDecisions < ActiveRecord::Migration[4.2]
   def change
     create_table :final_decisions do |t|
       t.boolean :admitted

--- a/db/migrate/20150407030634_devise_create_nonprofits.rb
+++ b/db/migrate/20150407030634_devise_create_nonprofits.rb
@@ -1,4 +1,4 @@
-class DeviseCreateNonprofits < ActiveRecord::Migration
+class DeviseCreateNonprofits < ActiveRecord::Migration[4.2]
   def change
     create_table(:nonprofits) do |t|
       ## Database authenticatable

--- a/db/migrate/20150414010907_create_nonprofit_applications.rb
+++ b/db/migrate/20150414010907_create_nonprofit_applications.rb
@@ -1,4 +1,4 @@
-class CreateNonprofitApplications < ActiveRecord::Migration
+class CreateNonprofitApplications < ActiveRecord::Migration[4.2]
   def change
     create_table :nonprofit_applications do |t|
       t.integer :nonprofit_id

--- a/db/migrate/20150414012425_create_member_roles.rb
+++ b/db/migrate/20150414012425_create_member_roles.rb
@@ -1,4 +1,4 @@
-class CreateMemberRoles < ActiveRecord::Migration
+class CreateMemberRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :member_roles do |t|
       t.timestamps

--- a/db/migrate/20150414012527_add_member_roles_to_member.rb
+++ b/db/migrate/20150414012527_add_member_roles_to_member.rb
@@ -1,4 +1,4 @@
-class AddMemberRolesToMember < ActiveRecord::Migration
+class AddMemberRolesToMember < ActiveRecord::Migration[4.2]
   def change
     add_column :members, :member_role_id, :integer
     add_index :members, :member_role_id

--- a/db/migrate/20150414020352_add_why_join_to_student_applications.rb
+++ b/db/migrate/20150414020352_add_why_join_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddWhyJoinToStudentApplications < ActiveRecord::Migration
+class AddWhyJoinToStudentApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :why_join, :text
   end

--- a/db/migrate/20150418233445_create_settings.rb
+++ b/db/migrate/20150418233445_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def change
     create_table :settings do |t|
       t.timestamps

--- a/db/migrate/20150419002935_add_singleton_guard_to_settings.rb
+++ b/db/migrate/20150419002935_add_singleton_guard_to_settings.rb
@@ -1,4 +1,4 @@
-class AddSingletonGuardToSettings < ActiveRecord::Migration
+class AddSingletonGuardToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :singleton_guard, :integer
   end

--- a/db/migrate/20150419003750_remove_singleton_guard.rb
+++ b/db/migrate/20150419003750_remove_singleton_guard.rb
@@ -1,4 +1,4 @@
-class RemoveSingletonGuard < ActiveRecord::Migration
+class RemoveSingletonGuard < ActiveRecord::Migration[4.2]
   def change
     remove_column :settings, :singleton_guard, :integer
   end

--- a/db/migrate/20150419003835_readd_singleton_guard.rb
+++ b/db/migrate/20150419003835_readd_singleton_guard.rb
@@ -1,4 +1,4 @@
-class ReaddSingletonGuard < ActiveRecord::Migration
+class ReaddSingletonGuard < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :singleton_guard, :integer
     add_index :settings, :singleton_guard, unique: true

--- a/db/migrate/20150420054104_add_resume_to_student_applications.rb
+++ b/db/migrate/20150420054104_add_resume_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddResumeToStudentApplications < ActiveRecord::Migration
+class AddResumeToStudentApplications < ActiveRecord::Migration[4.2]
   def self.up
     add_attachment :student_applications, :resume
   end

--- a/db/migrate/20150420062504_add_purpose_to_nonprofit_application.rb
+++ b/db/migrate/20150420062504_add_purpose_to_nonprofit_application.rb
@@ -1,4 +1,4 @@
-class AddPurposeToNonprofitApplication < ActiveRecord::Migration
+class AddPurposeToNonprofitApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :purpose, :text
   end

--- a/db/migrate/20150421022558_remove_current_semester_from_semester.rb
+++ b/db/migrate/20150421022558_remove_current_semester_from_semester.rb
@@ -1,4 +1,4 @@
-class RemoveCurrentSemesterFromSemester < ActiveRecord::Migration
+class RemoveCurrentSemesterFromSemester < ActiveRecord::Migration[4.2]
   def change
     remove_column :semesters, :is_current_semester, :boolean
   end

--- a/db/migrate/20150421025827_swap_current_semester_with_current_semester_id.rb
+++ b/db/migrate/20150421025827_swap_current_semester_with_current_semester_id.rb
@@ -1,4 +1,4 @@
-class SwapCurrentSemesterWithCurrentSemesterId < ActiveRecord::Migration
+class SwapCurrentSemesterWithCurrentSemesterId < ActiveRecord::Migration[4.2]
   def change
     remove_column :settings, :current_semester, :string
     add_column :settings, :current_semester_id, :integer

--- a/db/migrate/20150421052030_remove_npo_and_student_status.rb
+++ b/db/migrate/20150421052030_remove_npo_and_student_status.rb
@@ -1,4 +1,4 @@
-class RemoveNpoAndStudentStatus < ActiveRecord::Migration
+class RemoveNpoAndStudentStatus < ActiveRecord::Migration[4.2]
   def change
     remove_column :settings, :npo_status, :string
     remove_column :settings, :student_status, :string

--- a/db/migrate/20150421052123_readd_npo_and_student_status.rb
+++ b/db/migrate/20150421052123_readd_npo_and_student_status.rb
@@ -1,4 +1,4 @@
-class ReaddNpoAndStudentStatus < ActiveRecord::Migration
+class ReaddNpoAndStudentStatus < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :npo_app_open, :boolean
     add_column :settings, :student_app_open, :boolean

--- a/db/migrate/20150424091505_add_columns_to_student_application.rb
+++ b/db/migrate/20150424091505_add_columns_to_student_application.rb
@@ -1,4 +1,4 @@
-class AddColumnsToStudentApplication < ActiveRecord::Migration
+class AddColumnsToStudentApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :year, :string
     add_column :student_applications, :phone, :string

--- a/db/migrate/20150428030227_rename_admitted_to_decision.rb
+++ b/db/migrate/20150428030227_rename_admitted_to_decision.rb
@@ -1,4 +1,4 @@
-class RenameAdmittedToDecision < ActiveRecord::Migration
+class RenameAdmittedToDecision < ActiveRecord::Migration[4.2]
   def change
     rename_column :final_decisions, :admitted, :decision
     change_column :final_decisions, :decision, :string

--- a/db/migrate/20150504101213_remove_and_add_columns_from_nonprofits.rb
+++ b/db/migrate/20150504101213_remove_and_add_columns_from_nonprofits.rb
@@ -1,4 +1,4 @@
-class RemoveAndAddColumnsFromNonprofits < ActiveRecord::Migration
+class RemoveAndAddColumnsFromNonprofits < ActiveRecord::Migration[4.2]
   def change
     remove_column :nonprofits, :name, :string
     remove_column :nonprofits, :address, :string

--- a/db/migrate/20150505014507_add_columns_to_nonprofit_applications.rb
+++ b/db/migrate/20150505014507_add_columns_to_nonprofit_applications.rb
@@ -1,4 +1,4 @@
-class AddColumnsToNonprofitApplications < ActiveRecord::Migration
+class AddColumnsToNonprofitApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :history, :text
     add_column :nonprofit_applications, :date_established, :date

--- a/db/migrate/20150825192509_add_columns_to_student_applications.rb
+++ b/db/migrate/20150825192509_add_columns_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddColumnsToStudentApplications < ActiveRecord::Migration
+class AddColumnsToStudentApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :name, :string
     add_column :student_applications, :email, :string

--- a/db/migrate/20150826194109_add_alumnus_to_member.rb
+++ b/db/migrate/20150826194109_add_alumnus_to_member.rb
@@ -1,4 +1,4 @@
-class AddAlumnusToMember < ActiveRecord::Migration
+class AddAlumnusToMember < ActiveRecord::Migration[4.2]
   def change
     add_column :members, :is_alumnus, :boolean, default: false
   end

--- a/db/migrate/20151225012033_change_project_fields.rb
+++ b/db/migrate/20151225012033_change_project_fields.rb
@@ -1,4 +1,4 @@
-class ChangeProjectFields < ActiveRecord::Migration
+class ChangeProjectFields < ActiveRecord::Migration[4.2]
   def change
     change_table :projects do |t|
       t.remove :overview

--- a/db/migrate/20151225104530_add_image_to_projects.rb
+++ b/db/migrate/20151225104530_add_image_to_projects.rb
@@ -1,4 +1,4 @@
-class AddImageToProjects < ActiveRecord::Migration
+class AddImageToProjects < ActiveRecord::Migration[4.2]
   def change
     add_attachment :projects, :banner_image
   end

--- a/db/migrate/20160103043622_add_position_to_project.rb
+++ b/db/migrate/20160103043622_add_position_to_project.rb
@@ -1,4 +1,4 @@
-class AddPositionToProject < ActiveRecord::Migration
+class AddPositionToProject < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :position, :integer
     add_index :projects, :position

--- a/db/migrate/20160103102529_add_active_to_projects.rb
+++ b/db/migrate/20160103102529_add_active_to_projects.rb
@@ -1,4 +1,4 @@
-class AddActiveToProjects < ActiveRecord::Migration
+class AddActiveToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :published, :boolean, default: false
   end

--- a/db/migrate/20160113021137_add_cs169_boolean_to_nonprofit_application.rb
+++ b/db/migrate/20160113021137_add_cs169_boolean_to_nonprofit_application.rb
@@ -1,4 +1,4 @@
-class AddCs169BooleanToNonprofitApplication < ActiveRecord::Migration
+class AddCs169BooleanToNonprofitApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :cs169_pool, :boolean
   end

--- a/db/migrate/20160117021708_add_cs169_app_open_to_settings.rb
+++ b/db/migrate/20160117021708_add_cs169_app_open_to_settings.rb
@@ -1,4 +1,4 @@
-class AddCs169AppOpenToSettings < ActiveRecord::Migration
+class AddCs169AppOpenToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :cs169_app_open, :bool
   end

--- a/db/migrate/20160119012728_nonprofit_applications_cs169_pool_not_null.rb
+++ b/db/migrate/20160119012728_nonprofit_applications_cs169_pool_not_null.rb
@@ -1,4 +1,4 @@
-class NonprofitApplicationsCs169PoolNotNull < ActiveRecord::Migration
+class NonprofitApplicationsCs169PoolNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column_null :nonprofit_applications, :cs169_pool, false, false
   end

--- a/db/migrate/20160610035215_add_cs169_columns_to_application.rb
+++ b/db/migrate/20160610035215_add_cs169_columns_to_application.rb
@@ -1,4 +1,4 @@
-class AddCs169ColumnsToApplication < ActiveRecord::Migration
+class AddCs169ColumnsToApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :client_status, :string
     add_column :nonprofit_applications, :technical_requirements, :text

--- a/db/migrate/20160613054235_add_state_to_nonprofit_application.rb
+++ b/db/migrate/20160613054235_add_state_to_nonprofit_application.rb
@@ -1,4 +1,4 @@
-class AddStateToNonprofitApplication < ActiveRecord::Migration
+class AddStateToNonprofitApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :state, :string, null: false, default: 'draft'
   end

--- a/db/migrate/20160614042111_add_submitted_at_to_nonprofit_application.rb
+++ b/db/migrate/20160614042111_add_submitted_at_to_nonprofit_application.rb
@@ -1,4 +1,4 @@
-class AddSubmittedAtToNonprofitApplication < ActiveRecord::Migration
+class AddSubmittedAtToNonprofitApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_applications, :submitted_at, :datetime
   end

--- a/db/migrate/20160721044737_change_short_summary_on_nonprofit_application_from_string_to_text.rb
+++ b/db/migrate/20160721044737_change_short_summary_on_nonprofit_application_from_string_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeShortSummaryOnNonprofitApplicationFromStringToText < ActiveRecord::Migration
+class ChangeShortSummaryOnNonprofitApplicationFromStringToText < ActiveRecord::Migration[4.2]
   def up
     change_column :nonprofit_applications, :short_summary, :text, :limit => nil
   end

--- a/db/migrate/20160808053849_add_role_to_admin.rb
+++ b/db/migrate/20160808053849_add_role_to_admin.rb
@@ -1,4 +1,4 @@
-class AddRoleToAdmin < ActiveRecord::Migration
+class AddRoleToAdmin < ActiveRecord::Migration[4.2]
   def change
     change_column :admins, :role, :string, null: false, default: 'npo_reviewer'
   end

--- a/db/migrate/20160817001235_drop_member_and_member_role_tables.rb
+++ b/db/migrate/20160817001235_drop_member_and_member_role_tables.rb
@@ -1,4 +1,4 @@
-class DropMemberAndMemberRoleTables < ActiveRecord::Migration
+class DropMemberAndMemberRoleTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :member_roles
     drop_table :members

--- a/db/migrate/20160817002007_drop_projects_and_final_decisions_tables.rb
+++ b/db/migrate/20160817002007_drop_projects_and_final_decisions_tables.rb
@@ -1,4 +1,4 @@
-class DropProjectsAndFinalDecisionsTables < ActiveRecord::Migration
+class DropProjectsAndFinalDecisionsTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :projects
     drop_table :final_decisions

--- a/db/migrate/20160817170101_create_comparisons.rb
+++ b/db/migrate/20160817170101_create_comparisons.rb
@@ -1,4 +1,4 @@
-class CreateComparisons < ActiveRecord::Migration
+class CreateComparisons < ActiveRecord::Migration[4.2]
   def change
     create_table :comparisons do |t|
       t.timestamps

--- a/db/migrate/20160817170441_add_counts_to_student_application.rb
+++ b/db/migrate/20160817170441_add_counts_to_student_application.rb
@@ -1,4 +1,4 @@
-class AddCountsToStudentApplication < ActiveRecord::Migration
+class AddCountsToStudentApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :wins_count, :integer, default: 0
     add_column :student_applications, :losses_count, :integer, default: 0

--- a/db/migrate/20160817172905_add_comparison_variables_to_settings.rb
+++ b/db/migrate/20160817172905_add_comparison_variables_to_settings.rb
@@ -1,4 +1,4 @@
-class AddComparisonVariablesToSettings < ActiveRecord::Migration
+class AddComparisonVariablesToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :comparison_bonus, :integer, default: 0
     add_column :settings, :comparison_penalty, :integer, default: 0

--- a/db/migrate/20160821210920_add_fields_to_student_application.rb
+++ b/db/migrate/20160821210920_add_fields_to_student_application.rb
@@ -1,4 +1,4 @@
-class AddFieldsToStudentApplication < ActiveRecord::Migration
+class AddFieldsToStudentApplication < ActiveRecord::Migration[4.2]
   def up
     add_column :student_applications, :why_you, :text
     add_column :student_applications, :experience, :text

--- a/db/migrate/20160822012121_drop_identity_table.rb
+++ b/db/migrate/20160822012121_drop_identity_table.rb
@@ -1,4 +1,4 @@
-class DropIdentityTable < ActiveRecord::Migration
+class DropIdentityTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :identities
   end

--- a/db/migrate/20160822015108_remove_password_from_applicant.rb
+++ b/db/migrate/20160822015108_remove_password_from_applicant.rb
@@ -1,4 +1,4 @@
-class RemovePasswordFromApplicant < ActiveRecord::Migration
+class RemovePasswordFromApplicant < ActiveRecord::Migration[4.2]
   def change
     remove_column :applicants, :encrypted_password
   end

--- a/db/migrate/20160823023613_remove_why_you.rb
+++ b/db/migrate/20160823023613_remove_why_you.rb
@@ -1,4 +1,4 @@
-class RemoveWhyYou < ActiveRecord::Migration
+class RemoveWhyYou < ActiveRecord::Migration[4.2]
   def change
     remove_column :student_applications, :why_you
   end

--- a/db/migrate/20160901203939_create_holds.rb
+++ b/db/migrate/20160901203939_create_holds.rb
@@ -1,4 +1,4 @@
-class CreateHolds < ActiveRecord::Migration
+class CreateHolds < ActiveRecord::Migration[4.2]
   def change
     create_table :holds do |t|
       t.timestamps

--- a/db/migrate/20160902051758_add_current_until_to_hold.rb
+++ b/db/migrate/20160902051758_add_current_until_to_hold.rb
@@ -1,4 +1,4 @@
-class AddCurrentUntilToHold < ActiveRecord::Migration
+class AddCurrentUntilToHold < ActiveRecord::Migration[4.2]
   def change
     add_column :holds, :current_until, :datetime
   end

--- a/db/migrate/20170419235554_create_external_applications.rb
+++ b/db/migrate/20170419235554_create_external_applications.rb
@@ -1,4 +1,4 @@
-class CreateExternalApplications < ActiveRecord::Migration
+class CreateExternalApplications < ActiveRecord::Migration[4.2]
   def change
     create_table :external_applications do |t|
       t.string :name

--- a/db/migrate/20170419235739_add_attachment_resume_to_external_applications.rb
+++ b/db/migrate/20170419235739_add_attachment_resume_to_external_applications.rb
@@ -1,4 +1,4 @@
-class AddAttachmentResumeToExternalApplications < ActiveRecord::Migration
+class AddAttachmentResumeToExternalApplications < ActiveRecord::Migration[4.2]
   def self.up
     change_table :external_applications do |t|
       t.attachment :resume

--- a/db/migrate/20170422003501_add_external_app_open_to_settings.rb
+++ b/db/migrate/20170422003501_add_external_app_open_to_settings.rb
@@ -1,4 +1,4 @@
-class AddExternalAppOpenToSettings < ActiveRecord::Migration
+class AddExternalAppOpenToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :external_app_open, :boolean, default: true
   end

--- a/db/migrate/20170819215619_add_design_portfolio_to_student_applications.rb
+++ b/db/migrate/20170819215619_add_design_portfolio_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddDesignPortfolioToStudentApplications < ActiveRecord::Migration
+class AddDesignPortfolioToStudentApplications < ActiveRecord::Migration[4.2]
   def self.up
       add_attachment :student_applications, :design_portfolio
   end

--- a/db/migrate/20170820150625_add_add_to_newsletter_student_applications.rb
+++ b/db/migrate/20170820150625_add_add_to_newsletter_student_applications.rb
@@ -1,4 +1,4 @@
-class AddAddToNewsletterStudentApplications < ActiveRecord::Migration
+class AddAddToNewsletterStudentApplications < ActiveRecord::Migration[4.2]
   def change
       add_column :student_applications, :add_to_newsletter, :boolean, default:true
   end

--- a/db/migrate/20180105144836_add_fields_to_external_application_sp2018.rb
+++ b/db/migrate/20180105144836_add_fields_to_external_application_sp2018.rb
@@ -1,4 +1,4 @@
-class AddFieldsToExternalApplicationSp2018 < ActiveRecord::Migration
+class AddFieldsToExternalApplicationSp2018 < ActiveRecord::Migration[4.2]
   def change
     add_column :external_applications, :social_links, :text
     add_column :external_applications, :personal_growth, :text

--- a/db/migrate/20180105150300_add_commitments_to_external_application_sp2018.rb
+++ b/db/migrate/20180105150300_add_commitments_to_external_application_sp2018.rb
@@ -1,4 +1,4 @@
-class AddCommitmentsToExternalApplicationSp2018 < ActiveRecord::Migration
+class AddCommitmentsToExternalApplicationSp2018 < ActiveRecord::Migration[4.2]
   def change
     add_column :external_applications, :commitments, :text
   end

--- a/db/migrate/20180607000320_add_nonprofit_app_phases_to_settings.rb
+++ b/db/migrate/20180607000320_add_nonprofit_app_phases_to_settings.rb
@@ -1,4 +1,4 @@
-class AddNonprofitAppPhasesToSettings < ActiveRecord::Migration
+class AddNonprofitAppPhasesToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :npo_statement_of_interest_open, :boolean
     add_column :settings, :npo_project_proposal_open, :boolean

--- a/db/migrate/20180607011545_create_nonprofit_interest_forms.rb
+++ b/db/migrate/20180607011545_create_nonprofit_interest_forms.rb
@@ -1,4 +1,4 @@
-class CreateNonprofitInterestForms < ActiveRecord::Migration
+class CreateNonprofitInterestForms < ActiveRecord::Migration[4.2]
   def change
     create_table :nonprofit_interest_forms do |t|
       t.string :contact_name

--- a/db/migrate/20180710033449_add_notify_bar_to_settings.rb
+++ b/db/migrate/20180710033449_add_notify_bar_to_settings.rb
@@ -1,4 +1,4 @@
-class AddNotifyBarToSettings < ActiveRecord::Migration
+class AddNotifyBarToSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :settings, :notify_bar_active, :boolean
     add_column :settings, :notify_bar_content, :text

--- a/db/migrate/20180717003355_add_office_to_nonprofit_interest_forms.rb
+++ b/db/migrate/20180717003355_add_office_to_nonprofit_interest_forms.rb
@@ -1,4 +1,4 @@
-class AddOfficeToNonprofitInterestForms < ActiveRecord::Migration
+class AddOfficeToNonprofitInterestForms < ActiveRecord::Migration[4.2]
   def change
     add_column :nonprofit_interest_forms, :office, :string
   end

--- a/db/migrate/20180824061909_add_hardest_achievement_to_student_applications.rb
+++ b/db/migrate/20180824061909_add_hardest_achievement_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddHardestAchievementToStudentApplications < ActiveRecord::Migration
+class AddHardestAchievementToStudentApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :hardest_achievement, :text
   end

--- a/db/migrate/20180824064048_add_short_fields_to_student_applications.rb
+++ b/db/migrate/20180824064048_add_short_fields_to_student_applications.rb
@@ -1,4 +1,4 @@
-class AddShortFieldsToStudentApplications < ActiveRecord::Migration
+class AddShortFieldsToStudentApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :student_applications, :commitments, :text
     add_column :student_applications, :heard_from, :string

--- a/db/migrate/20180824153707_add_outreach_position_to_external_applications.rb
+++ b/db/migrate/20180824153707_add_outreach_position_to_external_applications.rb
@@ -1,4 +1,4 @@
-class AddOutreachPositionToExternalApplications < ActiveRecord::Migration
+class AddOutreachPositionToExternalApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :external_applications, :outreach, :boolean
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,239 +10,232 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180824153707) do
+ActiveRecord::Schema.define(version: 2018_08_24_153707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "admins", force: :cascade do |t|
+  create_table "admins", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "email",                  default: "",             null: false
-    t.string   "encrypted_password",     default: ""
-    t.string   "reset_password_token"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: ""
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.string   "role",                   default: "npo_reviewer", null: false
-    t.string   "invitation_token"
+    t.string "role", default: "npo_reviewer", null: false
+    t.string "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
-    t.integer  "invitation_limit"
-    t.integer  "invited_by_id"
-    t.string   "invited_by_type"
-    t.integer  "invitations_count",      default: 0
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.integer "invited_by_id"
+    t.integer "invitations_count", default: 0
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["invitation_token"], name: "index_admins_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_admins_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_admins_on_invited_by_id"
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  add_index "admins", ["email"], name: "index_admins_on_email", unique: true, using: :btree
-  add_index "admins", ["invitation_token"], name: "index_admins_on_invitation_token", unique: true, using: :btree
-  add_index "admins", ["invitations_count"], name: "index_admins_on_invitations_count", using: :btree
-  add_index "admins", ["invited_by_id"], name: "index_admins_on_invited_by_id", using: :btree
-  add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true, using: :btree
-
-  create_table "applicants", force: :cascade do |t|
+  create_table "applicants", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name"
-    t.string   "email",               default: "", null: false
+    t.string "name"
+    t.string "email", default: "", null: false
     t.datetime "remember_created_at"
+    t.index ["email"], name: "index_applicants_on_email", unique: true
   end
 
-  add_index "applicants", ["email"], name: "index_applicants_on_email", unique: true, using: :btree
-
-  create_table "comparisons", force: :cascade do |t|
+  create_table "comparisons", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "winner_id",  null: false
-    t.integer  "loser_id",   null: false
-    t.integer  "admin_id",   null: false
+    t.integer "winner_id", null: false
+    t.integer "loser_id", null: false
+    t.integer "admin_id", null: false
+    t.index ["admin_id"], name: "index_comparisons_on_admin_id"
+    t.index ["loser_id"], name: "index_comparisons_on_loser_id"
+    t.index ["winner_id"], name: "index_comparisons_on_winner_id"
   end
 
-  add_index "comparisons", ["admin_id"], name: "index_comparisons_on_admin_id", using: :btree
-  add_index "comparisons", ["loser_id"], name: "index_comparisons_on_loser_id", using: :btree
-  add_index "comparisons", ["winner_id"], name: "index_comparisons_on_winner_id", using: :btree
-
-  create_table "contact_forms", force: :cascade do |t|
+  create_table "contact_forms", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name"
-    t.string   "email"
-    t.string   "subject"
-    t.text     "message"
+    t.string "name"
+    t.string "email"
+    t.string "subject"
+    t.text "message"
   end
 
-  create_table "external_applications", force: :cascade do |t|
-    t.string   "name"
-    t.string   "phone"
-    t.string   "email"
-    t.integer  "applicant_id"
-    t.integer  "semester_id"
-    t.boolean  "operations"
-    t.boolean  "content"
-    t.boolean  "design"
-    t.boolean  "available_for_bp_games"
-    t.boolean  "available_for_retreat"
-    t.boolean  "applied_before"
-    t.text     "why_no_bp_games"
-    t.text     "why_no_retreat"
-    t.text     "why_join"
-    t.text     "design_experience"
-    t.text     "experience"
-    t.string   "website"
-    t.string   "year"
-    t.string   "major"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "resume_file_name"
-    t.string   "resume_content_type"
-    t.integer  "resume_file_size"
+  create_table "external_applications", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "phone"
+    t.string "email"
+    t.integer "applicant_id"
+    t.integer "semester_id"
+    t.boolean "operations"
+    t.boolean "content"
+    t.boolean "design"
+    t.boolean "available_for_bp_games"
+    t.boolean "available_for_retreat"
+    t.boolean "applied_before"
+    t.text "why_no_bp_games"
+    t.text "why_no_retreat"
+    t.text "why_join"
+    t.text "design_experience"
+    t.text "experience"
+    t.string "website"
+    t.string "year"
+    t.string "major"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "resume_file_name"
+    t.string "resume_content_type"
+    t.integer "resume_file_size"
     t.datetime "resume_updated_at"
-    t.text     "social_links"
-    t.text     "personal_growth"
-    t.string   "additional_option"
-    t.text     "commitments"
-    t.boolean  "outreach"
+    t.text "social_links"
+    t.text "personal_growth"
+    t.string "additional_option"
+    t.text "commitments"
+    t.boolean "outreach"
   end
 
-  create_table "holds", force: :cascade do |t|
+  create_table "holds", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "left_id",       null: false
-    t.integer  "right_id",      null: false
-    t.integer  "admin_id",      null: false
+    t.integer "left_id", null: false
+    t.integer "right_id", null: false
+    t.integer "admin_id", null: false
     t.datetime "current_until"
+    t.index ["admin_id"], name: "index_holds_on_admin_id"
+    t.index ["left_id"], name: "index_holds_on_left_id"
+    t.index ["right_id"], name: "index_holds_on_right_id"
   end
 
-  add_index "holds", ["admin_id"], name: "index_holds_on_admin_id", using: :btree
-  add_index "holds", ["left_id"], name: "index_holds_on_left_id", using: :btree
-  add_index "holds", ["right_id"], name: "index_holds_on_right_id", using: :btree
-
-  create_table "nonprofit_applications", force: :cascade do |t|
-    t.integer  "nonprofit_id"
-    t.integer  "semester_id"
+  create_table "nonprofit_applications", id: :serial, force: :cascade do |t|
+    t.integer "nonprofit_id"
+    t.integer "semester_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "purpose"
-    t.text     "history"
-    t.date     "date_established"
-    t.boolean  "legal"
-    t.text     "short_summary"
-    t.text     "goals"
-    t.text     "key_features"
-    t.string   "devices"
-    t.text     "target_audience"
-    t.text     "why"
-    t.boolean  "cs169_pool",                               null: false
-    t.string   "client_status"
-    t.text     "technical_requirements"
-    t.string   "state",                  default: "draft", null: false
+    t.text "purpose"
+    t.text "history"
+    t.date "date_established"
+    t.boolean "legal"
+    t.text "short_summary"
+    t.text "goals"
+    t.text "key_features"
+    t.string "devices"
+    t.text "target_audience"
+    t.text "why"
+    t.boolean "cs169_pool", null: false
+    t.string "client_status"
+    t.text "technical_requirements"
+    t.string "state", default: "draft", null: false
     t.datetime "submitted_at"
   end
 
-  create_table "nonprofit_interest_forms", force: :cascade do |t|
-    t.string   "contact_name"
-    t.string   "phone"
-    t.string   "role"
-    t.decimal  "office_lat"
-    t.decimal  "office_lng"
-    t.text     "org_description"
-    t.string   "website"
-    t.string   "category"
-    t.boolean  "agree_to_terms"
-    t.integer  "nonprofit_id"
-    t.integer  "semester_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.string   "office"
+  create_table "nonprofit_interest_forms", id: :serial, force: :cascade do |t|
+    t.string "contact_name"
+    t.string "phone"
+    t.string "role"
+    t.decimal "office_lat"
+    t.decimal "office_lng"
+    t.text "org_description"
+    t.string "website"
+    t.string "category"
+    t.boolean "agree_to_terms"
+    t.integer "nonprofit_id"
+    t.integer "semester_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "office"
   end
 
-  create_table "nonprofits", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "nonprofits", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "organization_name"
+    t.string "organization_name"
+    t.index ["email"], name: "index_nonprofits_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_nonprofits_on_reset_password_token", unique: true
   end
 
-  add_index "nonprofits", ["email"], name: "index_nonprofits_on_email", unique: true, using: :btree
-  add_index "nonprofits", ["reset_password_token"], name: "index_nonprofits_on_reset_password_token", unique: true, using: :btree
-
-  create_table "semesters", force: :cascade do |t|
+  create_table "semesters", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "season"
-    t.string   "year"
+    t.string "season"
+    t.string "year"
   end
 
-  create_table "settings", force: :cascade do |t|
+  create_table "settings", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "singleton_guard"
-    t.integer  "current_semester_id"
-    t.boolean  "npo_app_open"
-    t.boolean  "student_app_open"
-    t.boolean  "cs169_app_open"
-    t.integer  "comparison_bonus",               default: 0
-    t.integer  "comparison_penalty",             default: 0
-    t.integer  "comparison_threshold",           default: 0
-    t.integer  "applicants_remaining",           default: 0
-    t.boolean  "external_app_open",              default: true
-    t.boolean  "npo_statement_of_interest_open"
-    t.boolean  "npo_project_proposal_open"
-    t.boolean  "notify_bar_active"
-    t.text     "notify_bar_content"
-    t.string   "notify_bar_link"
+    t.integer "singleton_guard"
+    t.integer "current_semester_id"
+    t.boolean "npo_app_open"
+    t.boolean "student_app_open"
+    t.boolean "cs169_app_open"
+    t.integer "comparison_bonus", default: 0
+    t.integer "comparison_penalty", default: 0
+    t.integer "comparison_threshold", default: 0
+    t.integer "applicants_remaining", default: 0
+    t.boolean "external_app_open", default: true
+    t.boolean "npo_statement_of_interest_open"
+    t.boolean "npo_project_proposal_open"
+    t.boolean "notify_bar_active"
+    t.text "notify_bar_content"
+    t.string "notify_bar_link"
+    t.index ["current_semester_id"], name: "index_settings_on_current_semester_id"
+    t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 
-  add_index "settings", ["current_semester_id"], name: "index_settings_on_current_semester_id", using: :btree
-  add_index "settings", ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true, using: :btree
-
-  create_table "student_applications", force: :cascade do |t|
+  create_table "student_applications", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "applicant_id"
-    t.integer  "semester_id"
-    t.text     "why_join"
-    t.string   "resume_file_name"
-    t.string   "resume_content_type"
-    t.integer  "resume_file_size"
+    t.integer "applicant_id"
+    t.integer "semester_id"
+    t.text "why_join"
+    t.string "resume_file_name"
+    t.string "resume_content_type"
+    t.integer "resume_file_size"
     t.datetime "resume_updated_at"
-    t.string   "year"
-    t.string   "phone"
-    t.string   "name"
-    t.string   "email"
-    t.boolean  "available_for_bp_games",        default: false
-    t.boolean  "available_for_retreat",         default: false
-    t.integer  "wins_count",                    default: 0
-    t.integer  "losses_count",                  default: 0
-    t.text     "experience"
-    t.text     "projects"
-    t.text     "service"
-    t.text     "why_no_bp_games"
-    t.text     "why_no_retreat"
-    t.boolean  "applied_before",                default: false
-    t.integer  "version",                       default: 2
-    t.string   "design_portfolio_file_name"
-    t.string   "design_portfolio_content_type"
-    t.integer  "design_portfolio_file_size"
+    t.string "year"
+    t.string "phone"
+    t.string "name"
+    t.string "email"
+    t.boolean "available_for_bp_games", default: false
+    t.boolean "available_for_retreat", default: false
+    t.integer "wins_count", default: 0
+    t.integer "losses_count", default: 0
+    t.text "experience"
+    t.text "projects"
+    t.text "service"
+    t.text "why_no_bp_games"
+    t.text "why_no_retreat"
+    t.boolean "applied_before", default: false
+    t.integer "version", default: 2
+    t.string "design_portfolio_file_name"
+    t.string "design_portfolio_content_type"
+    t.integer "design_portfolio_file_size"
     t.datetime "design_portfolio_updated_at"
-    t.boolean  "add_to_newsletter",             default: true
-    t.text     "hardest_achievement"
-    t.text     "commitments"
-    t.string   "heard_from"
+    t.boolean "add_to_newsletter", default: true
+    t.text "hardest_achievement"
+    t.text "commitments"
+    t.string "heard_from"
+    t.index ["applicant_id"], name: "index_student_applications_on_applicant_id"
+    t.index ["semester_id"], name: "index_student_applications_on_semester_id"
   end
-
-  add_index "student_applications", ["applicant_id"], name: "index_student_applications_on_applicant_id", using: :btree
-  add_index "student_applications", ["semester_id"], name: "index_student_applications_on_semester_id", using: :btree
 
 end


### PR DESCRIPTION
Without this update, I couldn't run rails db:migrate from a fresh database. Details on this are here! https://stackoverflow.com/questions/48815984/rails5-directly-inheriting-from-from-activerecordmigration-is-not-supported-s